### PR TITLE
add logic to automatically renew certbot certificates if enabled

### DIFF
--- a/ansible/O1labs/cloud/playbooks/operator/setup_operator.yml
+++ b/ansible/O1labs/cloud/playbooks/operator/setup_operator.yml
@@ -5,9 +5,10 @@
     - role: "../../roles/operator"
       vars:
         enable_https: true
-        enable_certbot_certs: false
+        enable_certbot_certs: true
         email: zer0ne.io.x@gmail.com
         domain_names: [
           "operators.01labs.net",
-          "www.operators.01labs.net"
+          "www.operators.01labs.net",
+          "openops.01labs.net"
         ]

--- a/ansible/O1labs/cloud/roles/operator/defaults/main.yml
+++ b/ansible/O1labs/cloud/roles/operator/defaults/main.yml
@@ -13,6 +13,10 @@ https_port: 443
 
 enable_https: false
 enable_certbot_certs: false
+autorenew_certbot_certs: true
+# Reference https://docs.ansible.com/ansible/latest/collections/ansible/builtin/cron_module.html#parameter-special_time 
+# for frequency options
+autorenew_frequency: daily
 cert_dir: /var/www/certbot
 email:
 domain_names: []

--- a/ansible/O1labs/cloud/roles/operator/tasks/container/https_setup.yml
+++ b/ansible/O1labs/cloud/roles/operator/tasks/container/https_setup.yml
@@ -102,3 +102,10 @@
 - name: Reload nginx server
   when: enable_certbot_certs
   ansible.builtin.command: docker exec operator-nginx nginx -s reload
+
+- name: Create automatic certificate renewal cronjob
+  when: enable_certbot_certs and autorenew_certbot_certs
+  ansible.builtin.cron:
+    name: "automatically renew certbot certificates"
+    special_time: "{{ autorenew_frequency }}"
+    job: "docker run --rm --name cert_renewal -it -v operator_certs:{{ cert_dir }} -v certbot_certs:/etc/letsencrypt certbot/certbot:latest renew"


### PR DESCRIPTION
* also add `openops.01labs.net` domain to current O1 operator setup playbook