### PR TITLE
update O1 geth instance sync modes + lighthouse prater validator setup

### DIFF
--- a/ansible/O1labs/crypto/playbooks/ethereum/eth2_setup.yml
+++ b/ansible/O1labs/crypto/playbooks/ethereum/eth2_setup.yml
@@ -38,12 +38,15 @@
         eth2_chain: prater
         target_services: [ 'beacon-node', 'validator' ]
         setup_validator: "true"
+        override_keys_dir: /operations/lighthouse/keys
         host_data_dir: /operations/lighthouse/data
         host_keys_dir: /operations/lighthouse/keys
         beacon_extra_args: "--network=prater --eth1 --http --http-address=0.0.0.0 --http-allow-origin=* --metrics --metrics-address=0.0.0.0 --eth1-endpoints=http://ethereum-rpc.goerli.01labs.net:8545,https://goerli.infura.io/v3/4a3a6c645dc94d1b82f8f631a878e03c,http://geth:8545"
         beacon_env_vars: {}
-        validator_extra_args: "--network=prater --enable-doppelganger-protection=true --graffiti=O1 --http --http-address=0.0.0.0 --http-allow-origin=* --metrics --metrics-address=0.0.0.0 --metrics-allow-origin=* --unencrypted-http-transport --beacon-nodes=http://lighthouse-beacon:5052,http://lighthouse.prater.01labs.net:5052"
-        validator_env_vars: {}
+        validator_extra_args: "--network=prater --enable-doppelganger-protection=true --graffiti=O1 --http --http-address=0.0.0.0 --http-allow-origin=* --metrics --metrics-address=0.0.0.0 --metrics-allow-origin=* --unencrypted-http-transport --beacon-nodes=https://1zmZfn5jwHnW8kxtZ8JKZobXNge:4a7c68d25f0278b47bf77b2cdc2ea21f@eth2-beacon-prater.infura.io"
+        validator_env_vars:
+          SETUP_VALIDATOR: "true"
+          VALIDATOR_KEYSTORE_PASSWORD: "<insert-password>"
 
 - name: Setup Mainnet Prysm instances
   hosts: prysm_mainnet

--- a/ansible/O1labs/crypto/playbooks/ethereum/ethereum_setup.yml
+++ b/ansible/O1labs/crypto/playbooks/ethereum/ethereum_setup.yml
@@ -18,7 +18,7 @@
         chain: rinkeby
         config:
           Eth:
-            SyncMode: fast
+            SyncMode: full
 
 - name: Setup goerli geth instances
   hosts: geth_rpc_goerli
@@ -28,7 +28,7 @@
         chain: goerli
         config:
           Eth:
-            SyncMode: fast
+            SyncMode: full
 
 - name: Setup ropsten geth instances
   hosts: geth_rpc_ropsten
@@ -38,7 +38,7 @@
         chain: ropsten
         config:
           Eth:
-            SyncMode: fast
+            SyncMode: full
 
 - name: Setup mainnet geth instances
   hosts: geth_rpc_mainnet
@@ -49,4 +49,4 @@
         host_data_dir: /home/ahmad/lab/ethereum/geth/data
         config:
           Eth:
-            SyncMode: fast
+            SyncMode: full

--- a/ansible/O1labs/crypto/roles/lighthouse/README.md
+++ b/ansible/O1labs/crypto/roles/lighthouse/README.md
@@ -58,7 +58,7 @@ Example Playbook
 ```
   - role: o1labs.crypto.lighthouse
     vars:
-      target_services: ["lighthouse-beacon"]
+      target_services: ["beacon"]
       beacon_extra_args: "--network=prater --eth1-endpoints=http://ethereum-rpc.goerli.01labs.net:8545"
 ```
 

--- a/ansible/O1labs/crypto/roles/lighthouse/tasks/common/storage-setup.yml
+++ b/ansible/O1labs/crypto/roles/lighthouse/tasks/common/storage-setup.yml
@@ -10,7 +10,7 @@
 
 - name: Ensure existence of host wallet dir
   become: true
-  when: "'lighthouse-validator' in target_services"
+  when: "'validator' in target_services"
   file:
     path: "{{ host_wallet_dir }}"
     state: directory
@@ -18,7 +18,7 @@
 
 - name: Ensure existence of host keys dir
   become: true
-  when: "'lighthouse-validator' in target_services"
+  when: "'validator' in target_services"
   file:
     path: "{{ host_keys_dir }}"
     state: directory

--- a/ansible/inventory/O1_public.yml
+++ b/ansible/inventory/O1_public.yml
@@ -1,7 +1,7 @@
 all:
   hosts:
     cyclops:
-      ansible_host: 35.194.56.28
+      ansible_host: 34.132.190.208
       ansible_user: ops
     deadpool:
       ansible_host: 192.168.1.171
@@ -16,7 +16,7 @@ all:
       ansible_host: 107.214.58.44
       ansible_user: ahmad
     storm:
-      ansible_host: 34.66.198.174
+      ansible_host: 104.197.66.157
       ansible_user: ops
   children:
     chainlink_mainnet:


### PR DESCRIPTION
* update GCP node public IPs (cyclops and storm underwent reprovisioning due to expired GCP credits)
* ensure main eth2_setup playbook contains necessary properties to activate validator setup logic appropriately
* direct lighthouse prater validator at Infura beacon-node while O1 instance completes sync
* re-refactor lighthouse `target_services` property (conform to other client setups)