### PR TITLE
chore(frontend): bump react to 19.2.8 to match react-dom

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.5",
-        "react": "^18.3.1",
+        "react": "19.2.8",
         "react-dom": "^19.2.8",
         "react-scripts": "5.0.1",
         "web-vitals": "^6.1.1"
@@ -13670,12 +13670,10 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26259,12 +26257,9 @@
       }
     },
     "react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="
     },
     "react-app-polyfill": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.5",
-    "react": "^18.3.1",
+    "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-scripts": "5.0.1",
     "web-vitals": "^6.1.1"


### PR DESCRIPTION
## Summary
- Completes the React 19 upgrade after Dependabot #101 merged `react-dom@19.2.8`
- Bumps `react` from `^18.3.1` to `^19.2.8` and refreshes the lockfile
- Supersedes conflicting Dependabot PR #98

## Test plan
- [ ] `cd frontend && npm ci && npm test -- --watchAll=false`
- [ ] Confirm package versions: `react` and `react-dom` both 19.2.8


Made with [Cursor](https://cursor.com)