### PR TITLE
fix: make Galaxy collection publish idempotent

### DIFF
--- a/.github/workflows/galaxy-collection-publish.yml
+++ b/.github/workflows/galaxy-collection-publish.yml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         collection: [cloud, crypto]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
@@ -31,10 +31,22 @@ jobs:
         env:
           GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
         run: |
-          if [ -z "$GALAXY_API_KEY" ]; then
+          set -euo pipefail
+          if [ -z "${GALAXY_API_KEY:-}" ]; then
             echo "GALAXY_API_KEY secret is not set" >&2
             exit 1
           fi
+
+          version=$(awk '/^version:/ {print $2; exit}' galaxy.yml)
+          echo "galaxy.yml version=${version}"
+
+          # Skip if this version is already on Galaxy (idempotent on re-push)
+          api="https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/o1labs/${{ matrix.collection }}/versions/${version}/"
+          if curl -fsSIL "$api" >/dev/null 2>&1; then
+            echo "o1labs.${{ matrix.collection }}:${version} already published; skipping"
+            exit 0
+          fi
+
           ansible-galaxy collection build --force
           tarball=$(ls -1 o1labs-${{ matrix.collection }}-*.tar.gz | head -1)
           ansible-galaxy collection publish "$tarball" --api-key "$GALAXY_API_KEY"


### PR DESCRIPTION
## Summary
- Skip collection publish when the `galaxy.yml` version already exists on Galaxy
- Bump checkout/setup-python to v7

## Test plan
- [ ] workflow_dispatch with current 0.1.6 skips cleanly
- [ ] New version still publishes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection publishing reliability with safer validation and error handling.
  * Prevented attempts to republish collection versions that already exist on Galaxy.
  * Added clearer version reporting during the publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->